### PR TITLE
fix: simai grammar file not found from CWD

### DIFF
--- a/Views/MainWindow.axaml.cs
+++ b/Views/MainWindow.axaml.cs
@@ -35,7 +35,7 @@ public partial class MainWindow : Window
         var _registryOptions = new RegistryOptions(ThemeName.DarkPlus);
         var _install = TextMate.InstallTextMate(textEditor, _registryOptions);
         var registry = new Registry(_install.RegistryOptions);
-        _install.SetGrammarFile("simai.tmLanguage.json");
+        _install.SetGrammarFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "simai.tmLanguage.json"));
         //setup visualizer
         simaiVisual = this.FindControl<SimaiVisualizerControl>("SimaiVisual");
         simaiVisual.PointerWheelChanged += SimaiVisual_PointerWheelChanged;
@@ -147,5 +147,5 @@ public partial class MainWindow : Window
         }
     }
 
-    
+
 }


### PR DESCRIPTION
The program crashed due to it tried to look for the `simai.tmLanguage.json` from current working directory.

```
Unhandled exception. System.IO.FileNotFoundException: Could not find file '/home/z4hyrei/mhome/workspace/majdataedit/simai.tmLanguage.json'.
File name: '/home/z4hyrei/mhome/workspace/majdataedit/simai.tmLanguage.json'
   at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
   at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, Int64 preallocationSize)
   at System.IO.StreamReader.ValidateArgsAndOpenPath(String path, Encoding encoding, Int32 bufferSize)
   at System.IO.StreamReader..ctor(String path)
   at TextMateSharp.Registry.Registry.LoadGrammarFromPathSync(String path, Int32 initialLanguage, Dictionary`2 embeddedLanguages) in /_/src/TextMateSharp/Registry/Registry.cs:line 101
   at AvaloniaEdit.TextMate.TextMate.Installation.SetGrammarFile(String path)
   at MajdataEdit_Neo.Views.MainWindow..ctor() in /build/source/Views/MainWindow.axaml.cs:line 37
   at MajdataEdit_Neo.App.OnFrameworkInitializationCompleted() in /build/source/App.axaml.cs:line 26
   at Avalonia.AppBuilder.SetupUnsafe()
   at Avalonia.AppBuilder.Setup()
   at Avalonia.AppBuilder.SetupWithLifetime(IApplicationLifetime lifetime)
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder builder, String[] args, Action`1 lifetimeBuilder)
   at MajdataEdit_Neo.Program.Main(String[] args) in /build/source/Program.cs:line 12
zsh: IOT instruction (core dumped)  NIXPKGS_ALLOW_UNFREE=1 nix run --impure .\#majdataedit
```

I was torn between `AppDomain.CurrentDomain.BaseDirectory` and `System.Environment.CurrentDirectory`, but [looks like the former is the correct choice](https://stackoverflow.com/questions/674857/should-i-use-appdomain-currentdomain-basedirectory-or-system-environment-current).